### PR TITLE
fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 build:
-	rm digdarm.zip
+	rm -f digdarm.zip
 	zip -r digdarm.zip * -x Makefile README.md


### PR DESCRIPTION
Currently, the Makefile only works if digdarm.zip is already available. The present commit fixes this issue.